### PR TITLE
Make path to LINQPAD.exe independent from source location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,4 @@
-DynamicLinqPadPostgreSqlDriver/obj/
+obj/
+bin/
 packages/
-DynamicLinqPadPostgreSqlDriver/bin/
-DynamicLinqPadPostgreSqlDriver.UI/obj/
-DynamicLinqPadPostgreSqlDriver.UI/bin/
-DynamicLinqPadPostgreSqlDriver.Shared/obj/
-DynamicLinqPadPostgreSqlDriver.Shared/bin/
-DynamicLinqPadPostgreSqlDriver.Tests/obj/
-DynamicLinqPadPostgreSqlDriver.Tests/bin/
+*.suo

--- a/DynamicLinqPadPostgreSqlDriver.Shared/DynamicLinqPadPostgreSqlDriver.Shared.csproj
+++ b/DynamicLinqPadPostgreSqlDriver.Shared/DynamicLinqPadPostgreSqlDriver.Shared.csproj
@@ -41,7 +41,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="LINQPad">
-      <HintPath>..\..\..\Program Files (x86)\LINQPad5\LINQPad.exe</HintPath>
+      <HintPath>$(LINQPAD_HOME)\LINQPad.exe</HintPath>
     </Reference>
     <Reference Include="Npgsql, Version=3.0.4.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
       <HintPath>..\packages\Npgsql.3.0.4\lib\net45\Npgsql.dll</HintPath>

--- a/DynamicLinqPadPostgreSqlDriver.UI/DynamicLinqPadPostgreSqlDriver.UI.csproj
+++ b/DynamicLinqPadPostgreSqlDriver.UI/DynamicLinqPadPostgreSqlDriver.UI.csproj
@@ -46,7 +46,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="LINQPad">
-      <HintPath>..\..\..\Program Files (x86)\LINQPad5\LINQPad.exe</HintPath>
+      <HintPath>$(LINQPAD_HOME)\LINQPad.exe</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/DynamicLinqPadPostgreSqlDriver/DynamicLinqPadPostgreSqlDriver.csproj
+++ b/DynamicLinqPadPostgreSqlDriver/DynamicLinqPadPostgreSqlDriver.csproj
@@ -46,7 +46,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="LINQPad">
-      <HintPath>..\..\..\Program Files (x86)\LINQPad5\LINQPad.exe</HintPath>
+      <HintPath>$(LINQPAD_HOME)\LINQPad.exe</HintPath>
     </Reference>
     <Reference Include="Npgsql, Version=3.0.4.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
       <HintPath>..\packages\Npgsql.3.0.4\lib\net45\Npgsql.dll</HintPath>


### PR DESCRIPTION
Thank you for your awesome work! When checking out the source code compilation failed because the path to LINQPAD in the csproj files was defined in a relative path that did not resolve on my system (my source code is not on c:).
This environment variable - once set - would make it work for arbitrary LINQPAD install locations.