### PR TITLE
Order tables by name for ExplorerItem view

### DIFF
--- a/DynamicLinqPadPostgreSqlDriver/DynamicPostgreSqlDriver.cs
+++ b/DynamicLinqPadPostgreSqlDriver/DynamicPostgreSqlDriver.cs
@@ -99,7 +99,7 @@ namespace DynamicLinqPadPostgreSqlDriver
 
                var preparedTables = new List<TableData>();
                
-               foreach(var table in group)
+               foreach(var table in group.OrderBy(t => t.TableName))
                {
                   var unmodifiedTableName = (string)table.TableName;
                   var tableName = cxInfo.GetTableName(unmodifiedTableName);


### PR DESCRIPTION
We have about 40 tables in our database and it is really hard to find the right one at a glance without alphabetical sorting.