### PR TITLE
Fix case in DatabaseFixture.ProviderName

### DIFF
--- a/DynamicLinqPadPostgreSqlDriver.Tests/DynamicAssemblyGeneration/DatabaseFixture.cs
+++ b/DynamicLinqPadPostgreSqlDriver.Tests/DynamicAssemblyGeneration/DatabaseFixture.cs
@@ -7,7 +7,7 @@ namespace DynamicLinqPadPostgreSqlDriver.Tests.DynamicAssemblyGeneration
 {
    public class DatabaseFixture : IDisposable
    {
-      public const string ProviderName = "PostgreSql";
+      public const string ProviderName = "PostgreSQL";
       public const string ConnectionString = "Server=localhost;Port=5433;Database=TestDb_DynamicAssemblyGeneration;User Id=postgres;Password=postgres;";
 
       public IDbConnection DBConnection { get; }


### PR DESCRIPTION
The DynamicAssemblyGeneration-Tests were failing due to a "Provider PostgeSql not found" error on the current master. Got it fixed by changing "PostgreSql" to "PostgreSQL" in DatabaseFixture.