### PR TITLE
Add ddl editing support

### DIFF
--- a/DynamicLinqPadPostgreSqlDriver/DDL/CommandTextInterceptor.cs
+++ b/DynamicLinqPadPostgreSqlDriver/DDL/CommandTextInterceptor.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+
+namespace DynamicLinqPadPostgreSqlDriver.DDL
+{
+   /// <summary>
+   /// DDL statements in LINQPad are baked in unfortunately. With the help
+   /// of this interceptor we can work around this limitation by rewriting the 
+   /// statements to be compatible with PostgreSql
+   /// </summary>
+   public class CommandTextInterceptor
+   {
+      public string GetCommandText(string commandText)
+      {
+         if (commandText.StartsWith("DROP FUNCTION"))
+         {
+            // DROP FUNCTION [dbo].[xyz] => DROP FUNCTION public.xyz;
+            commandText = commandText.Replace("[dbo]", "public").Replace("[", "").Replace("]", "") + ";";
+         }
+         // sp_helptext is SqlServer specific and needs to be replaced by its PostgreSql equivalent
+         if (commandText.StartsWith("sp_helptext"))
+         {
+            var funcName = Regex.Match(commandText, "(?<=(dbo\\.)).*(?=\\()");
+            commandText = $"select pg_get_functiondef(oid) from pg_proc where proname = '{funcName}';";
+         }
+         return commandText;
+      }
+   }
+}

--- a/DynamicLinqPadPostgreSqlDriver/DDL/DbCommandProxy.cs
+++ b/DynamicLinqPadPostgreSqlDriver/DDL/DbCommandProxy.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using Npgsql;
+
+namespace DynamicLinqPadPostgreSqlDriver.DDL
+{
+   [Serializable]
+   public class DbCommandProxy : DbCommand
+   {
+      private readonly CommandTextInterceptor interceptor = new CommandTextInterceptor();
+      private readonly DbCommand original;
+
+      public DbCommandProxy(DbCommand original)
+      {
+         if (original == null)
+         {
+            throw new ArgumentNullException(nameof(original));
+         }
+         this.original = original;
+      }
+
+      private T HandleEx<T>(Func<T> func)
+      {
+         try
+         {
+            return func();
+         }
+         // NpgsqlException does not implement MarshalByRefObject and therefore causes a SerializationException
+         // when thrown, obfuscating the real error message.
+         catch (NpgsqlException ex)
+         {
+            throw new DataException($"{ex.Message} --- {CommandText}");
+         }
+      }
+
+      public new void Dispose()
+      {
+         original.Dispose();
+      }
+
+      public override void Prepare()
+      {
+         original.Prepare();
+      }
+
+      public override void Cancel()
+      {
+         original.Cancel();
+      }
+
+      public new IDbDataParameter CreateParameter()
+      {
+         return original.CreateParameter();
+      }
+
+      protected override DbParameter CreateDbParameter()
+      {
+         return original.CreateParameter();
+      }
+
+      protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+      {
+         return HandleEx(() => original.ExecuteReader(behavior));
+      }
+
+      public override int ExecuteNonQuery()
+      {
+         return HandleEx(() => original.ExecuteNonQuery());
+      }
+
+      public new IDataReader ExecuteReader()
+      {
+         return HandleEx(() => original.ExecuteReader());
+      }
+
+      public new IDataReader ExecuteReader(CommandBehavior behavior)
+      {
+         return HandleEx(() => original.ExecuteReader(behavior));
+      }
+
+      public override object ExecuteScalar()
+      {
+         return HandleEx(() => original.ExecuteScalar());
+      }
+
+      public new DbConnection Connection
+      {
+         get
+         {
+            return DbConnection;
+         }
+         set
+         {
+            DbConnection = value;
+         }
+      }
+
+      protected override DbConnection DbConnection
+      {
+         get
+         {
+            return original.Connection;
+         }
+         set
+         {
+            if (value is DbConnectionProxy)
+            {
+               original.Connection = ((DbConnectionProxy)value).Original;
+            }
+            else
+            {
+               original.Connection = value;
+            }
+         }
+      }
+
+      protected override DbParameterCollection DbParameterCollection => original.Parameters;
+
+      protected override DbTransaction DbTransaction
+      {
+         get
+         {
+            return original.Transaction;
+         }
+         set
+         {
+            original.Transaction = value;
+         }
+      }
+
+      public override bool DesignTimeVisible
+      {
+         get
+         {
+            return original.DesignTimeVisible;
+         }
+         set
+         {
+            original.DesignTimeVisible = value;
+         }
+      }
+
+      public new DbTransaction Transaction
+      {
+         get
+         {
+            return original.Transaction;
+         }
+         set
+         {
+            original.Transaction = value;
+         }
+      }
+
+      public override string CommandText
+      {
+         get
+         {
+            return original.CommandText;
+         }
+         set
+         {
+            original.CommandText = interceptor.GetCommandText(value);
+         }
+      }
+
+      public override int CommandTimeout
+      {
+         get
+         {
+            return original.CommandTimeout;
+         }
+         set
+         {
+            original.CommandTimeout = value;
+         }
+      }
+
+      public override CommandType CommandType
+      {
+         get
+         {
+            return original.CommandType;
+         }
+         set
+         {
+            original.CommandType = value;
+         }
+      }
+
+      public new IDataParameterCollection Parameters => original.Parameters;
+
+      public override UpdateRowSource UpdatedRowSource
+      {
+         get
+         {
+            return original.UpdatedRowSource;
+         }
+         set
+         {
+            original.UpdatedRowSource = value;
+         }
+      }
+   }
+}

--- a/DynamicLinqPadPostgreSqlDriver/DDL/DbConnectionProxy.cs
+++ b/DynamicLinqPadPostgreSqlDriver/DDL/DbConnectionProxy.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Data;
+using System.Data.Common;
+using System.Reflection;
+
+namespace DynamicLinqPadPostgreSqlDriver.DDL
+{
+   [Serializable]
+   public class DbConnectionProxy : DbConnection
+   {
+      internal readonly DbConnection Original;
+
+      public DbConnectionProxy(DbConnection original)
+      {
+         if (original == null)
+         {
+            throw new ArgumentNullException(nameof(original));
+         }
+         Original = original;
+      }
+
+      public new void Dispose()
+      {
+         Original.Dispose();
+      }
+
+      protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+      {
+         return Original.BeginTransaction(isolationLevel);
+      }
+
+      public new IDbTransaction BeginTransaction()
+      {
+         return Original.BeginTransaction();
+      }
+
+      public new IDbTransaction BeginTransaction(IsolationLevel il)
+      {
+         return Original.BeginTransaction(il);
+      }
+
+      public override void Close()
+      {
+         Original.Close();
+      }
+
+      public override void ChangeDatabase(string databaseName)
+      {
+         Original.ChangeDatabase(databaseName);
+      }
+
+      public new IDbCommand CreateCommand()
+      {
+         return new DbCommandProxy(Original.CreateCommand());
+      }
+
+      protected override DbCommand CreateDbCommand()
+      {
+         return new DbCommandProxy(Original.CreateCommand());
+      }
+
+      public override void Open()
+      {
+         Original.Open();
+      }
+
+      public override string ConnectionString {
+         get
+         {
+            return Original.ConnectionString;
+         }
+         set
+         {
+            Original.ConnectionString = value;
+         }
+      }
+      public override int ConnectionTimeout => Original.ConnectionTimeout;
+      public override string Database => Original.Database;
+      public override string DataSource => Original.DataSource;
+      public override string ServerVersion => Original.ServerVersion;
+      public override ConnectionState State => Original.State;
+
+      /// <summary>
+      /// This is accessed in the LINQPad code via reflection
+      /// </summary>
+      protected override DbProviderFactory DbProviderFactory
+      {
+         get
+         {
+            var providerFactoryMethod = Original.GetType().GetProperty("DbProviderFactory", BindingFlags.Instance | BindingFlags.NonPublic);
+            var originalFactory = (DbProviderFactory)providerFactoryMethod?.GetValue(Original) ?? base.DbProviderFactory;
+            return new DbProviderFactoryProxy(originalFactory);
+         }
+      }
+   }
+}

--- a/DynamicLinqPadPostgreSqlDriver/DDL/DbProviderFactoryProxy.cs
+++ b/DynamicLinqPadPostgreSqlDriver/DDL/DbProviderFactoryProxy.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Data.Common;
+
+namespace DynamicLinqPadPostgreSqlDriver.DDL
+{
+   /// <summary>
+   /// The ProviderFactory is retrieved by LINQPad via reflection, so it needs to
+   /// be replaced to return a <see cref="DbCommandProxy"/> instead of the underlying command.
+   /// </summary>
+   public class DbProviderFactoryProxy : DbProviderFactory
+   {
+      private readonly DbProviderFactory original;
+
+      public DbProviderFactoryProxy(DbProviderFactory original)
+      {
+         if (original == null)
+         {
+            throw new ArgumentNullException(nameof(original));
+         }
+         this.original = original;
+      }
+
+      public override DbCommand CreateCommand()
+      {
+         return new DbCommandProxy(original.CreateCommand());
+      }
+
+      public override DbDataAdapter CreateDataAdapter()
+      {
+         return original.CreateDataAdapter();
+      }
+   }
+}

--- a/DynamicLinqPadPostgreSqlDriver/DynamicLinqPadPostgreSqlDriver.csproj
+++ b/DynamicLinqPadPostgreSqlDriver/DynamicLinqPadPostgreSqlDriver.csproj
@@ -68,6 +68,15 @@
       <Link>VersionInfo.cs</Link>
     </Compile>
     <Compile Include="DatabaseObjectProviderManager.cs" />
+    <Compile Include="DDL\DbCommandProxy.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="DDL\DbConnectionProxy.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="DDL\CommandTextInterceptor.cs" />
+    <Compile Include="DDL\DbProviderFactoryProxy.cs" />
+    <Compile Include="Extensions\ExplorerItemExtensions.cs" />    
     <Compile Include="Extensions\IConnectionInfoExtensions.cs" />
     <Compile Include="Extensions\IDbConnectionExtensions.cs" />
     <Compile Include="Extensions\ILGeneratorExtensions.cs" />

--- a/DynamicLinqPadPostgreSqlDriver/DynamicPostgreSqlDriver.cs
+++ b/DynamicLinqPadPostgreSqlDriver/DynamicPostgreSqlDriver.cs
@@ -10,6 +10,7 @@ using System.Reflection.Emit;
 using System.IO;
 using LinqToDB.Data;
 using System.Data;
+using DynamicLinqPadPostgreSqlDriver.DDL;
 using DynamicLinqPadPostgreSqlDriver.Extensions;
 using DynamicLinqPadPostgreSqlDriver.UI;
 using DynamicLinqPadPostgreSqlDriver.Shared.Extensions;
@@ -38,7 +39,8 @@ namespace DynamicLinqPadPostgreSqlDriver
          var connectionString = cxInfo.GetPostgreSqlConnectionString();
 
          var connection = new NpgsqlConnection(connectionString);
-         return connection;
+         
+         return new DbConnectionProxy(connection);
       }
 
       public override IEnumerable<string> GetAssembliesToAdd(IConnectionInfo cxInfo)

--- a/DynamicLinqPadPostgreSqlDriver/Extensions/ExplorerItemExtensions.cs
+++ b/DynamicLinqPadPostgreSqlDriver/Extensions/ExplorerItemExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Reflection;
+using LINQPad.Extensibility.DataContext;
+
+namespace DynamicLinqPadPostgreSqlDriver.Extensions
+{
+   public static class ExplorerItemExtensions
+   {
+      public static void SupportsDDLEditing(this ExplorerItem explorerItem, bool value)
+      {
+         var ddlEditingField = typeof(ExplorerItem).GetField("SupportsDDLEditing", BindingFlags.NonPublic | BindingFlags.Instance);
+         ddlEditingField?.SetValue(explorerItem, true);
+      }
+   }
+}

--- a/DynamicLinqPadPostgreSqlDriver/Extensions/ExplorerItemExtensions.cs
+++ b/DynamicLinqPadPostgreSqlDriver/Extensions/ExplorerItemExtensions.cs
@@ -8,7 +8,7 @@ namespace DynamicLinqPadPostgreSqlDriver.Extensions
       public static void SupportsDDLEditing(this ExplorerItem explorerItem, bool value)
       {
          var ddlEditingField = typeof(ExplorerItem).GetField("SupportsDDLEditing", BindingFlags.NonPublic | BindingFlags.Instance);
-         ddlEditingField?.SetValue(explorerItem, true);
+         ddlEditingField?.SetValue(explorerItem, value);
       }
    }
 }

--- a/DynamicLinqPadPostgreSqlDriver/PostgreSqlFunctionsProvider.cs
+++ b/DynamicLinqPadPostgreSqlDriver/PostgreSqlFunctionsProvider.cs
@@ -199,8 +199,11 @@ namespace DynamicLinqPadPostgreSqlDriver
          var explorerItem = new ExplorerItem(func.Name, ExplorerItemKind.QueryableObject, funcType)
          {
             IsEnumerable = true,
-            Children = paramExplorerItems
+            Children = paramExplorerItems,
+            SqlName = $"{func.Name}({string.Join(",", paramTypes.Select(x => x.DbTypeName))})"
          };
+
+         explorerItem.SupportsDDLEditing(true);
 
          return explorerItem;
       }


### PR DESCRIPTION
Enables the function context menu known from the baked-in driver for PostgreSQL functions: 
![pgsql_functions_contextmenu](https://cloud.githubusercontent.com/assets/8522449/15242791/5383c592-18f8-11e6-8138-71972c645d90.png)

The solution is a bit hacky because unfortunately there are no real extension points provided by the Linqpad API. All of the methods are hardcoded for SQL Server so we have to intercept the statements before they are sent to the database server and rewrite them in PgSql.

One thing we cannot intercept is the "ALTER" statement in function definitions:
![pgsql_functions_edit](https://cloud.githubusercontent.com/assets/8522449/15242909/f16091e6-18f8-11e6-959b-7eabe34002f2.png)

This is a simple String.Replace in the Linqpad codebase so we can do nothing about it for now. 
