### PR TITLE
Convert type name for array types in a UserDefinedType

### DIFF
--- a/DynamicLinqPadPostgreSqlDriver.Tests/DynamicAssemblyGeneration/TestPostgreSqlFunctions.cs
+++ b/DynamicLinqPadPostgreSqlDriver.Tests/DynamicAssemblyGeneration/TestPostgreSqlFunctions.cs
@@ -110,7 +110,7 @@ namespace DynamicLinqPadPostgreSqlDriver.Tests.DynamicAssemblyGeneration
       {
          dynamic dc = ArrangeDataContext(db =>
          {
-            DBConnection.Execute("CREATE TYPE testtype AS (id int, name text);");
+            DBConnection.Execute("CREATE TYPE testtype AS (id int, name text, arrayprop integer[]);");
             DBConnection.Execute("CREATE FUNCTION public.echo_udt(testtype) RETURNS testtype AS 'SELECT $1' LANGUAGE SQL;");
          });
 

--- a/DynamicLinqPadPostgreSqlDriver/DbTypeData.cs
+++ b/DynamicLinqPadPostgreSqlDriver/DbTypeData.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace DynamicLinqPadPostgreSqlDriver
+{
+   internal class DbTypeData
+   {
+      public string DbType { get; private set; }
+      public string UdtName { get; private set; }
+
+      /// <summary>
+      /// Convert the <see cref="typeName"/> to <see cref="DbTypeData"/> that is in the
+      /// correct form to be understood by <see cref="SqlHelper.MapDbTypeToType"/>
+      /// (has to be done for arrays in user defined types)
+      /// </summary>
+      public static DbTypeData FromString(string typeName)
+      {
+         var arrayIdentifierPos = typeName?.IndexOf("[]", StringComparison.Ordinal)??-1;
+         if (arrayIdentifierPos >= 0)
+         {
+            return new DbTypeData
+            {
+               DbType = "array",
+               UdtName = typeName?.Remove(arrayIdentifierPos)
+            };
+         }
+
+         return new DbTypeData { DbType = typeName };
+      }
+   }
+}

--- a/DynamicLinqPadPostgreSqlDriver/DynamicLinqPadPostgreSqlDriver.csproj
+++ b/DynamicLinqPadPostgreSqlDriver/DynamicLinqPadPostgreSqlDriver.csproj
@@ -68,6 +68,7 @@
       <Link>VersionInfo.cs</Link>
     </Compile>
     <Compile Include="DatabaseObjectProviderManager.cs" />
+    <Compile Include="DbTypeData.cs" />
     <Compile Include="Extensions\IConnectionInfoExtensions.cs" />
     <Compile Include="Extensions\IDbConnectionExtensions.cs" />
     <Compile Include="Extensions\ILGeneratorExtensions.cs" />

--- a/DynamicLinqPadPostgreSqlDriver/PostgreSqlFunctionsProvider.cs
+++ b/DynamicLinqPadPostgreSqlDriver/PostgreSqlFunctionsProvider.cs
@@ -87,7 +87,7 @@ namespace DynamicLinqPadPostgreSqlDriver
             {
                var attrName = cxInfo.GetColumnName((string)attr.AttributeName);
                var attrTypeData = DbTypeData.FromString(attr.AttributeType);
-               var attrType = SqlHelper.MapDbTypeToType(attrTypeData?.DbType, attrTypeData?.UdtName, false, true);
+               var attrType = SqlHelper.MapDbTypeToType(attrTypeData.DbType, attrTypeData.UdtName, false, true);
                if (attrType == null)
                {
                   throw new InvalidOperationException("Unknown type: " + attr.AttributeType);

--- a/DynamicLinqPadPostgreSqlDriver/PostgreSqlFunctionsProvider.cs
+++ b/DynamicLinqPadPostgreSqlDriver/PostgreSqlFunctionsProvider.cs
@@ -86,7 +86,8 @@ namespace DynamicLinqPadPostgreSqlDriver
             foreach (var attr in udtAttributes)
             {
                var attrName = cxInfo.GetColumnName((string)attr.AttributeName);
-               var attrType = SqlHelper.MapDbTypeToType(attr.AttributeType, null, false, true);
+               var attrTypeData = DbTypeData.FromString(attr.AttributeType);
+               var attrType = SqlHelper.MapDbTypeToType(attrTypeData?.DbType, attrTypeData?.UdtName, false, true);
                if (attrType == null)
                {
                   throw new InvalidOperationException("Unknown type: " + attr.AttributeType);


### PR DESCRIPTION
… so they get recognized by the MapDbTypeToType helper method and do not result in a crash.

Previously, if a user defined type appeared in a PgSql function and that type had a property of type array, the driver would crash and render the database inaccessible for Linqpad.