### PR TITLE
Fix crash on functions with defaults

### DIFF
--- a/DynamicLinqPadPostgreSqlDriver.Tests/DynamicAssemblyGeneration/InputParameterTestData.cs
+++ b/DynamicLinqPadPostgreSqlDriver.Tests/DynamicAssemblyGeneration/InputParameterTestData.cs
@@ -1,0 +1,19 @@
+﻿namespace DynamicLinqPadPostgreSqlDriver.Tests.DynamicAssemblyGeneration
+{
+   /// <summary>
+   /// Test data for testing different signatures on pgsql functions
+   /// </summary>
+   public class InputParameterTestData
+   {
+      public string Name { get; }
+      public string PgSqlType { get; }
+      public object Default { get; }
+
+      public InputParameterTestData(string name, string pgSqlType, object defaultValue = null)
+      {
+         Name = name;
+         PgSqlType = pgSqlType;
+         Default = defaultValue;
+      }
+   }
+}

--- a/DynamicLinqPadPostgreSqlDriver.Tests/DynamicAssemblyGeneration/TestPostgreSqlFunctions.cs
+++ b/DynamicLinqPadPostgreSqlDriver.Tests/DynamicAssemblyGeneration/TestPostgreSqlFunctions.cs
@@ -148,5 +148,20 @@ namespace DynamicLinqPadPostgreSqlDriver.Tests.DynamicAssemblyGeneration
          dynamic record = result[0];
          Assert.Equal("[[1,5],[99,100]]", record.get_json);
       }
+
+      [Fact]
+      public void TestSimpleParameterWithDefault()
+      {
+         TestInputParametersWithDefault(new InputParameterTestData("id", "integer", 0));
+      }
+
+      [Fact]
+      public void TestMultipleParametersWithDefault()
+      {
+         TestInputParametersWithDefault(
+            new InputParameterTestData("txt", "text", "'comma,separated,text'"),
+            new InputParameterTestData("id", "integer", 0),
+            new InputParameterTestData("arr", "int[]", "'{1,2}'"));
+      }
    }
 }

--- a/DynamicLinqPadPostgreSqlDriver.Tests/DynamicLinqPadPostgreSqlDriver.Tests.csproj
+++ b/DynamicLinqPadPostgreSqlDriver.Tests/DynamicLinqPadPostgreSqlDriver.Tests.csproj
@@ -88,6 +88,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DynamicAssemblyGeneration\DatabaseFixture.cs" />
+    <Compile Include="DynamicAssemblyGeneration\InputParameterTestData.cs" />
     <Compile Include="DynamicAssemblyGeneration\TestBase.cs" />
     <Compile Include="DynamicAssemblyGeneration\TestPostgreSqlFunctions.cs" />
     <Compile Include="TestAdvancedTypeMappings.cs" />

--- a/DynamicLinqPadPostgreSqlDriver/FunctionData.cs
+++ b/DynamicLinqPadPostgreSqlDriver/FunctionData.cs
@@ -7,7 +7,7 @@ namespace DynamicLinqPadPostgreSqlDriver
       public int ArgumentCount { get; set; }
       public string[] ArgumentNames { get; set; }
       public int[] ArgumentTypeOids { get; set; }
-      public object[] ArgumentDefaults { get; set; }
+      public string ArgumentDefaults { get; set; }
       public bool IsMultiValueReturn { get; set; }
    }
 }

--- a/DynamicLinqPadPostgreSqlDriver/SQL/QueryFunctions.sql
+++ b/DynamicLinqPadPostgreSqlDriver/SQL/QueryFunctions.sql
@@ -4,7 +4,7 @@
 	, pronargs AS "ArgumentCount"
 	, proargnames AS "ArgumentNames"
 	, proargtypes AS "ArgumentTypeOids"
-	, proargdefaults AS "ArgumentDefaults"
+	, pg_get_expr(proargdefaults, 0) AS "ArgumentDefaults"
 	, proretset AS "IsMultiValueReturn"
 from 
     pg_proc 


### PR DESCRIPTION
Fixes #16 

Implemented in a way that allows for default argument interpretation in a later iteration. For now the csharp methods are generated without considering defaults.