### PR TITLE
Fix udt recognition

### DIFF
--- a/DynamicLinqPadPostgreSqlDriver.Shared/DynamicLinqPadPostgreSqlDriver.Shared.csproj
+++ b/DynamicLinqPadPostgreSqlDriver.Shared/DynamicLinqPadPostgreSqlDriver.Shared.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamicLinqPadPostgreSqlDriver.Shared</RootNamespace>
     <AssemblyName>DynamicLinqPadPostgreSqlDriver.Shared</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/DynamicLinqPadPostgreSqlDriver.Tests/DynamicLinqPadPostgreSqlDriver.Tests.csproj
+++ b/DynamicLinqPadPostgreSqlDriver.Tests/DynamicLinqPadPostgreSqlDriver.Tests.csproj
@@ -11,10 +11,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamicLinqPadPostgreSqlDriver.Tests</RootNamespace>
     <AssemblyName>DynamicLinqPadPostgreSqlDriver.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/DynamicLinqPadPostgreSqlDriver.Tests/app.config
+++ b/DynamicLinqPadPostgreSqlDriver.Tests/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.7.142.0" newVersion="4.7.142.0" />
+        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.7.142.0" newVersion="4.7.142.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>

--- a/DynamicLinqPadPostgreSqlDriver.UI/DynamicLinqPadPostgreSqlDriver.UI.csproj
+++ b/DynamicLinqPadPostgreSqlDriver.UI/DynamicLinqPadPostgreSqlDriver.UI.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamicLinqPadPostgreSqlDriver.UI</RootNamespace>
     <AssemblyName>DynamicLinqPadPostgreSqlDriver.UI</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/DynamicLinqPadPostgreSqlDriver/DynamicLinqPadPostgreSqlDriver.csproj
+++ b/DynamicLinqPadPostgreSqlDriver/DynamicLinqPadPostgreSqlDriver.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamicLinqPadPostgreSqlDriver</RootNamespace>
     <AssemblyName>DynamicLinqPadPostgreSqlDriver</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/DynamicLinqPadPostgreSqlDriver/PostgreSqlFunctionsProvider.cs
+++ b/DynamicLinqPadPostgreSqlDriver/PostgreSqlFunctionsProvider.cs
@@ -96,10 +96,13 @@ namespace DynamicLinqPadPostgreSqlDriver
             {
                var attrName = cxInfo.GetColumnName((string)attr.AttributeName);
                var attrTypeData = DbTypeData.FromString(attr.AttributeType);
-               var attrType = SqlHelper.MapDbTypeToType(attrTypeData.DbType, attrTypeData.UdtName, false, true);
+               Type attrType = SqlHelper.MapDbTypeToType(attrTypeData.DbType, attrTypeData.UdtName, false, true);
                if (attrType == null)
                {
-                  throw new InvalidOperationException("Unknown type: " + attr.AttributeType);
+                  if (!TryGetOrCreateUserDefinedType(attrTypeData.DbType, out attrType))
+                  {
+                     throw new InvalidOperationException("Unknown type: " + attr.AttributeType);
+                  }
                }
 
                typeBuilder.DefineField(attrName, attrType, FieldAttributes.Public);


### PR DESCRIPTION
Fixes #18 and fixes #25. You still cannot call functions with UDT arguments from generated LINQPad C# code, but there should be no more exceptions generating the datacontext because of this.
Tested this on the official postgis docker image, where I could reproduce the issues, and extended the relevant test case to ensure it stays fixed.

Bumped the framework version to 4.6 because that was the version I had to use to compile against the latest LINQPad release.